### PR TITLE
Merge crossbar config with OCS crossbar config

### DIFF
--- a/components/hub/.crossbar/config.json
+++ b/components/hub/.crossbar/config.json
@@ -10,7 +10,7 @@
             },
             "realms": [
                 {
-                    "name": "sisock",
+                    "name": "test_realm",
                     "roles": [
                         {
                             "name": "server",
@@ -41,6 +41,46 @@
                                     "allow": {
                                         "call": true,
                                         "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
+                        },
+                        {
+                            "name": "iocs_agent",
+                            "permissions": [
+                                {
+                                    "uri": "observatory.",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
+                        },
+                        {
+                            "name": "iocs_controller",
+                            "permissions": [
+                                {
+                                    "uri": "observatory.",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": false,
                                         "publish": true,
                                         "subscribe": true
                                     },
@@ -90,6 +130,19 @@
                             }
                         }
                     }
+                },
+                {
+                    "type": "websocket",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 8001
+                    },
+                    "auth": {
+                        "anonymous": {
+                            "type": "static",
+                            "role": "server"
+                        }
+                    }
                 }
             ]
         },
@@ -104,7 +157,7 @@
                 {
                     "type": "class",
                     "classname": "hub.hub",
-                    "realm": "sisock",
+                    "realm": "test_realm",
                     "transport": {
                         "type": "websocket",
                         "endpoint": {

--- a/sisock/base.py
+++ b/sisock/base.py
@@ -41,7 +41,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 WAMP_USER   = u"server"
 WAMP_SECRET = u"Q5#x4%HCmgTsS!Pj"
 WAMP_URI    = u"wss://127.0.0.1:8080/ws"
-REALM       = u"sisock"
+REALM       = u"test_realm"
 BASE_URI        = u"org.simonsobservatory"
 
 def uri(s):


### PR DESCRIPTION
Our goal is for a sisock DataNodeServer to subscribe to data feeds provided by
OCS to provide live monitoring in grafana. While the autobahn documentation
leads one to believe a single Component can communicate with multiple crossbar
servers, in practice we have yet to implement that. This led us to using a
common crossbar server.

One change here is the realm name. We've moved to the OCS realm, 'realm1', from
'sisock'. This provides the common namespace for pub/sub and RPC.

For compatability with OCS we've added the OCS roles, 'iocs_agent' and
'iocs_controller', and the unsecured websocket transport on port 8001.

For interoperability between sisock and OCS we've also switched the auth on
port 8001 to use the 'server' role. This is needed, as sisock needs to
communicate with uri's that don't match the 'observatory.' prefix enforced for
the 'iocs_agent' role. If this uri prefix for OCS needs to be this strict this
should be fixed, but at the time of writing it's not entirely clear to the
author the best way to accomplish this and maintain sisock/ocs communication.

This config allows sisock and ocs to run off of the same crossbar server, as
well as communicate with each other.