### PR TITLE
Fix dynamically generated fields don't exist bug

### DIFF
--- a/components/data_node_servers/thermometry/thermometry_server.py
+++ b/components/data_node_servers/thermometry/thermometry_server.py
@@ -61,7 +61,6 @@ class thermometry_server(sisock.base.DataNodeServer):
     def onChallenge(self, challenge):
         self.log.info('authentication challenge received')
 
-    @inlineCallbacks
     def onJoin(self, details):
         """Override parent method. See parent class for documentation. It is
         triggered after successfully joining WAMP session. 

--- a/sisock/base.py
+++ b/sisock/base.py
@@ -94,7 +94,6 @@ class DataNodeServer(ApplicationSession):
     name = None
     description = None
 
-    @inlineCallbacks
     def onJoin(self, details):
         """Fired when the session joins WAMP (after successful authentication).
 
@@ -117,7 +116,8 @@ class DataNodeServer(ApplicationSession):
         # Run after join routines
         self.after_onJoin(details)
 
-    def _register_procedures(details):
+    @inlineCallbacks
+    def _register_procedures(self, details):
         """Register get_fields, get_data procedures with the hub.
 
         Parameters
@@ -134,7 +134,8 @@ class DataNodeServer(ApplicationSession):
             except Exception as e:
                 self.log.error("Could not register procedure: %s." % (e))
 
-    def _report_availability(details):
+    @inlineCallbacks
+    def _report_availability(self, details):
         """Report to the hub that this data_node is available to serve data.
 
         Parameters


### PR DESCRIPTION
This PR addresses the issue mentioned in #16. A quick summary of the problem is that dynamically generated fields only exist after data arrives, and before that any call to `get_fields` return no results. I think this is due to data node server prematurely declaring its availability to the hub when its fields are still unavailable. Here I changed it to only report availability to the hub after the data arrives and the fields have been populated, which I think makes more sense. This way we can be sure that any node added to the hub will work reliably. 