### PR TITLE
Use docker-compose to build images in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ python:
 stages:
   - test
   - name: dockerize
-    if: branch = master AND \
-        tag IS present
+    if: |
+      branch = master AND \
+      tag IS present
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ dist: xenial
 services:
   - docker
 
-env:
-  global:
-    - IMAGE_NAME=sisock
-
 language: python
 python:
   - "3.6"
@@ -14,7 +10,8 @@ python:
 stages:
   - test
   - name: dockerize
-    #if: tag IS present
+    #if: branch = master AND \
+    #    tag IS present
 
 jobs:
   include:
@@ -37,11 +34,6 @@ jobs:
         # Build the docker images with docker-compose
         - docker-compose build
 
-        ## Build the docker image
-        #- docker build -t ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG} .
-        ## Make sure we can import sisock in container
-        #- docker run --rm ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG} /usr/bin/python3 -c "import sisock"
-
       after_success:
         # Tag all images for upload to the registry
         - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${REGISTRY_URL}/{}:latest"
@@ -50,9 +42,4 @@ jobs:
         # Upload to docker registry
         - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${REGISTRY_URL}/{}:${DOCKER_TAG}"
         - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${REGISTRY_URL}/{}:latest"
-        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo '${REGISTRY_URL}/{}:${DOCKER_TAG} pushed'"
-        ## Upload docker image
-        #- docker push ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG}
-        #- docker tag ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG} ${REGISTRY_URL}/${IMAGE_NAME}:latest
-        #- docker push ${REGISTRY_URL}/${IMAGE_NAME}:latest
-        #- echo "Docker image 'docker push ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG}' pushed"
+        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo ${REGISTRY_URL}/{}:${DOCKER_TAG} pushed"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,25 @@ jobs:
         - echo "${REGISTRY_PASSWORD}" | docker login "${REGISTRY_URL}" -u "${REGISTRY_USER}" --password-stdin;
 
       script:
-        # Build the docker image
-        - docker build -t ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG} .
-        # Make sure we can import sisock in container
-        - docker run --rm ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG} /usr/bin/python3 -c "import sisock"
+        # Build the docker images with docker-compose
+        - docker-compose build
+
+        ## Build the docker image
+        #- docker build -t ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG} .
+        ## Make sure we can import sisock in container
+        #- docker run --rm ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG} /usr/bin/python3 -c "import sisock"
 
       after_success:
-        # Upload docker image
-        - docker push ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG}
-        - docker tag ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG} ${REGISTRY_URL}/${IMAGE_NAME}:latest
-        - docker push ${REGISTRY_URL}/${IMAGE_NAME}:latest
-        - echo "Docker image 'docker push ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG}' pushed"
+        # Tag all images for upload to the registry
+        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${REGISTRY_URL}/{}:latest"
+        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker tag {}:latest ${REGISTRY_URL}/{}:${DOCKER_TAG}"
+
+        # Upload to docker registry
+        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${REGISTRY_URL}/{}:${DOCKER_TAG}"
+        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} docker push ${REGISTRY_URL}/{}:latest"
+        - "docker-compose config | grep 'image: ' | awk -F ': ' '{ print $2 }' | xargs -I {} echo '${REGISTRY_URL}/{}:${DOCKER_TAG} pushed'"
+        ## Upload docker image
+        #- docker push ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG}
+        #- docker tag ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG} ${REGISTRY_URL}/${IMAGE_NAME}:latest
+        #- docker push ${REGISTRY_URL}/${IMAGE_NAME}:latest
+        #- echo "Docker image 'docker push ${REGISTRY_URL}/${IMAGE_NAME}:${DOCKER_TAG}' pushed"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ python:
 stages:
   - test
   - name: dockerize
-    #if: branch = master AND \
-    #    tag IS present
+    if: branch = master AND \
+        tag IS present
 
 jobs:
   include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,17 @@
 # sisock
 # A containerized sisock installation.
 
-# Various parent images have been used, the latest being so3g
+# Build on so3g base image
 FROM grumpy.physics.yale.edu/so3g:0.0.4
-#FROM spt3g:36d0c3d
-#FROM python:3
 
 # Set timezone to UTC
 ENV TZ=Etc/UTC
 
 # Set the working directory to /app
-WORKDIR /app
+WORKDIR /sisock
 
 # Copy the current directory contents into the container at /app
-ADD . /app
+ADD . /sisock
 
 # Install any needed packages specified in requirements.txt
 RUN pip3 install -r requirements.txt .

--- a/components/data_node_servers/apex_weather/Makefile
+++ b/components/data_node_servers/apex_weather/Makefile
@@ -1,4 +1,4 @@
-NAME=dans-apex-weather
+NAME=sisock-apex-weather-server
 
 build :
 	docker build -t ${NAME} .

--- a/components/data_node_servers/g3_reader/Dockerfile
+++ b/components/data_node_servers/g3_reader/Dockerfile
@@ -1,9 +1,8 @@
 # sisock g3_reader
 # sisock DataNodeServer serving g3 files from disk.
 
-# Use sisock-spt3g base image
+# Use sisock base image
 FROM sisock:latest
-#FROM sisock:0.2.2
 
 # Copy the current directory contents into the container at /app
 COPY requirements.txt /tmp/

--- a/components/data_node_servers/g3_reader/Makefile
+++ b/components/data_node_servers/g3_reader/Makefile
@@ -1,4 +1,4 @@
-NAME=dans-g3-reader
+NAME=sisock-g3-reader-server
 
 build :
 	docker build -t ${NAME} .

--- a/components/data_node_servers/radiometer/Makefile
+++ b/components/data_node_servers/radiometer/Makefile
@@ -1,4 +1,4 @@
-NAME=dans-ucsc-radiometer
+NAME=sisock-radiometer-server
 
 build :
 	docker build -t ${NAME} .

--- a/components/data_node_servers/sensors/Makefile
+++ b/components/data_node_servers/sensors/Makefile
@@ -1,4 +1,4 @@
-NAME=dans-example-sensors
+NAME=sisock-sensors-server
 
 build :
 	docker build -t ${NAME} .

--- a/components/data_node_servers/thermometry/Makefile
+++ b/components/data_node_servers/thermometry/Makefile
@@ -1,4 +1,4 @@
-NAME=dans-thermometry
+NAME=sisock-thermometry-server
 
 build :
 	docker build -t ${NAME} .

--- a/components/data_node_servers/weather/Makefile
+++ b/components/data_node_servers/weather/Makefile
@@ -1,4 +1,4 @@
-NAME=dans-example-weather
+NAME=sisock-weather-server
 
 build :
 	docker build -t ${NAME} .

--- a/components/g3_file_scanner/Dockerfile
+++ b/components/g3_file_scanner/Dockerfile
@@ -2,8 +2,8 @@
 # Periodically scan the data directory, parse g3 files, and add information
 # about them to a MySQL database.
 
-# Use spt3g base image.
-FROM grumpy.physics.yale.edu/so3g:0.0.4
+# Use sisock base image
+FROM sisock:latest
 
 # Copy the current directory contents into the container at /app
 COPY requirements.txt /tmp/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,133 @@
+version: '3.2'
+services:
+  # --------------------------------------------------------------------------
+  # The sisock library.
+  # --------------------------------------------------------------------------
+  sisock:
+    image: "sisock"
+    build: .
+
+  # --------------------------------------------------------------------------
+  # Core Components
+  # --------------------------------------------------------------------------
+  
+  # --------------------------------------------------------------------------
+  # This service is required by all others (except grafana).
+  # --------------------------------------------------------------------------
+  sisock-crossbar:
+    image: "sisock-crossbar"
+    build: ./components/hub/
+    depends_on:
+      - "sisock"
+
+  # --------------------------------------------------------------------------
+  # A bridge between sisock and grafana: read data from sisock and serve it to
+  # grafana over HTTP.
+  # --------------------------------------------------------------------------
+  sisock-http:
+    image: "sisock-http"
+    build: ./components/grafana_server/
+    depends_on:
+      - "sisock"
+
+  # --------------------------------------------------------------------------
+  # Data node servier: the following three services are for serving local g3
+  # files with sisock: a database, a file-scanner, and a file-reader.
+  # --------------------------------------------------------------------------
+  sisock-g3-file-scanner:
+    image: "sisock-g3-file-scanner"
+    build: ./components/g3_file_scanner/
+    depends_on:
+      - "sisock"
+
+  # --------------------------------------------------------------------------
+  # Data Node Servers
+  # --------------------------------------------------------------------------
+
+#  g3-reader:
+#    image: "g3-reader"
+#    build: ${SISOCK_DIR}/components/data_node_servers/g3_reader/
+#    volumes:
+#      - ${SISOCK_HK_DIR}:/data:ro
+#      - ./.crossbar:/app/.crossbar
+#    environment:
+#        SQL_HOST: "database"
+#        SQL_USER: "development"
+#        SQL_PASSWD: "development"
+#        SQL_DB: "files"
+#        MAX_POINTS: 1000
+#    depends_on:
+#      - "sisock-crossbar"
+#      - "database"
+#      - "g3-file-scanner"
+#
+#  # --------------------------------------------------------------------------
+#  # Data node server: an example that streams system sensor information. This is
+#  # an example that doesn't require any special hardware or external files.
+#  # --------------------------------------------------------------------------
+#  sensors-server:
+#    image: "sensors-server"
+#    container_name: sensors-server
+#    build: ${SISOCK_DIR}/components/data_node_servers/sensors/
+#    volumes:
+#      - ./.crossbar:/app/.crossbar
+#    depends_on:
+#      - "sisock-crossbar"
+#
+#  # --------------------------------------------------------------------------
+#  # Data node server: an example weather server that doesn't require any
+#  # special hardware or external files (it comes with its own data files).
+#  # --------------------------------------------------------------------------
+#  weather-server:
+#    image: "weather-server"
+#    container_name: weather-server
+#    build: ${SISOCK_DIR}/components/data_node_servers/weather/
+#    depends_on:
+#      - "sisock-crossbar"
+#
+#  # --------------------------------------------------------------------------
+#  # Data node server: serves radiometer data stored on the local machine.
+#  # --------------------------------------------------------------------------
+#  radiometer-server:
+#    image: "radiometer-server"
+#    container_name: radiometer-server
+#    build: ${SISOCK_DIR}/components/data_node_servers/radiometer/
+#    environment:
+#        MAX_POINTS: 1000
+#    volumes:
+#      - ${SISOCK_RADIOMETER_DIR}:/data:ro
+#      - ./.crossbar:/app/.crossbar
+#    depends_on:
+#      - "sisock-crossbar"
+#
+#  # --------------------------------------------------------------------------
+#  # Data node server: serves APEX data stored on the local machine.
+#  # --------------------------------------------------------------------------
+#  apex-weather-server:
+#    image: "apex-weather-server"
+#    container_name: apex-weather-server
+#    build: ${SISOCK_DIR}/components/data_node_servers/apex_weather/
+#    environment:
+#        MAX_POINTS: 1000
+#    volumes:
+#      - ${SISOCK_APEX_DIR}:/data:ro
+#      - ./.crossbar:/app/.crossbar
+#    depends_on:
+#      - "sisock-crossbar"
+#
+#  # --------------------------------------------------------------------------
+#  # Data node server: LS372 measurement.
+#  # --------------------------------------------------------------------------
+#  ls372-measurement:
+#    image: "ls372-measurement"
+#    container_name: ls372-measurement
+#    build: ${SISOCK_DIR}/components/data_node_servers/thermometry/
+#    environment:
+#        TARGET: measurement # Match to instance-id of agent to monitor, used
+#                            # for data feed subscription.
+#        NAME: 'LSA22HA' # Will appear in sisock a front of field name.
+#        DESCRIPTION: "LS372 measuring test board in the lab."
+#    volumes:
+#      - ./.crossbar:/app/.crossbar
+#    depends_on:
+#      - "sisock-crossbar"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,8 @@ services:
       - "sisock"
 
   # --------------------------------------------------------------------------
-  # Data node servier: the following three services are for serving local g3
-  # files with sisock: a database, a file-scanner, and a file-reader.
+  # For serving local g3 files with sisock: a file-scanner which logs
+  # information to a database.
   # --------------------------------------------------------------------------
   sisock-g3-file-scanner:
     image: "sisock-g3-file-scanner"
@@ -44,90 +44,59 @@ services:
   # Data Node Servers
   # --------------------------------------------------------------------------
 
-#  g3-reader:
-#    image: "g3-reader"
-#    build: ${SISOCK_DIR}/components/data_node_servers/g3_reader/
-#    volumes:
-#      - ${SISOCK_HK_DIR}:/data:ro
-#      - ./.crossbar:/app/.crossbar
-#    environment:
-#        SQL_HOST: "database"
-#        SQL_USER: "development"
-#        SQL_PASSWD: "development"
-#        SQL_DB: "files"
-#        MAX_POINTS: 1000
-#    depends_on:
-#      - "sisock-crossbar"
-#      - "database"
-#      - "g3-file-scanner"
-#
-#  # --------------------------------------------------------------------------
-#  # Data node server: an example that streams system sensor information. This is
-#  # an example that doesn't require any special hardware or external files.
-#  # --------------------------------------------------------------------------
-#  sensors-server:
-#    image: "sensors-server"
-#    container_name: sensors-server
-#    build: ${SISOCK_DIR}/components/data_node_servers/sensors/
-#    volumes:
-#      - ./.crossbar:/app/.crossbar
-#    depends_on:
-#      - "sisock-crossbar"
-#
-#  # --------------------------------------------------------------------------
-#  # Data node server: an example weather server that doesn't require any
-#  # special hardware or external files (it comes with its own data files).
-#  # --------------------------------------------------------------------------
-#  weather-server:
-#    image: "weather-server"
-#    container_name: weather-server
-#    build: ${SISOCK_DIR}/components/data_node_servers/weather/
-#    depends_on:
-#      - "sisock-crossbar"
-#
-#  # --------------------------------------------------------------------------
-#  # Data node server: serves radiometer data stored on the local machine.
-#  # --------------------------------------------------------------------------
-#  radiometer-server:
-#    image: "radiometer-server"
-#    container_name: radiometer-server
-#    build: ${SISOCK_DIR}/components/data_node_servers/radiometer/
-#    environment:
-#        MAX_POINTS: 1000
-#    volumes:
-#      - ${SISOCK_RADIOMETER_DIR}:/data:ro
-#      - ./.crossbar:/app/.crossbar
-#    depends_on:
-#      - "sisock-crossbar"
-#
-#  # --------------------------------------------------------------------------
-#  # Data node server: serves APEX data stored on the local machine.
-#  # --------------------------------------------------------------------------
-#  apex-weather-server:
-#    image: "apex-weather-server"
-#    container_name: apex-weather-server
-#    build: ${SISOCK_DIR}/components/data_node_servers/apex_weather/
-#    environment:
-#        MAX_POINTS: 1000
-#    volumes:
-#      - ${SISOCK_APEX_DIR}:/data:ro
-#      - ./.crossbar:/app/.crossbar
-#    depends_on:
-#      - "sisock-crossbar"
-#
-#  # --------------------------------------------------------------------------
-#  # Data node server: LS372 measurement.
-#  # --------------------------------------------------------------------------
-#  ls372-measurement:
-#    image: "ls372-measurement"
-#    container_name: ls372-measurement
-#    build: ${SISOCK_DIR}/components/data_node_servers/thermometry/
-#    environment:
-#        TARGET: measurement # Match to instance-id of agent to monitor, used
-#                            # for data feed subscription.
-#        NAME: 'LSA22HA' # Will appear in sisock a front of field name.
-#        DESCRIPTION: "LS372 measuring test board in the lab."
-#    volumes:
-#      - ./.crossbar:/app/.crossbar
-#    depends_on:
-#      - "sisock-crossbar"
+  # --------------------------------------------------------------------------
+  # Data node server: serves APEX data stored on the local machine.
+  # --------------------------------------------------------------------------
+  sisock-apex-weather-server:
+    image: "sisock-apex-weather-server"
+    build: ./components/data_node_servers/apex_weather/
+    depends_on:
+      - "sisock"
+
+  # --------------------------------------------------------------------------
+  # Data node server: the following three services are for serving local g3
+  # files with sisock: a database, a file-scanner, and a file-reader.
+  # --------------------------------------------------------------------------
+  sisock-g3-reader-server:
+    image: "sisock-g3-reader-server"
+    build: ./components/data_node_servers/g3_reader/
+    depends_on:
+      - "sisock"
+
+  # --------------------------------------------------------------------------
+  # Data node server: serves radiometer data stored on the local machine.
+  # --------------------------------------------------------------------------
+  sisock-radiometer-server:
+    image: "sisock-radiometer-server"
+    build: ./components/data_node_servers/radiometer/
+    depends_on:
+      - "sisock"
+
+  # --------------------------------------------------------------------------
+  # Data node server: an example that streams system sensor information. This is
+  # an example that doesn't require any special hardware or external files.
+  # --------------------------------------------------------------------------
+  sisock-sensors-server:
+    image: "sisock-sensors-server"
+    build: ./components/data_node_servers/sensors/
+    depends_on:
+      - "sisock"
+
+  # --------------------------------------------------------------------------
+  # Data node server: Thermometry OCS subscriber
+  # --------------------------------------------------------------------------
+  sisock-thermometry-server:
+    image: "sisock-thermometry-server"
+    build: ./components/data_node_servers/thermometry/
+    depends_on:
+      - "sisock"
+
+  # --------------------------------------------------------------------------
+  # Data node server: an example weather server that doesn't require any
+  # special hardware or external files (it comes with its own data files).
+  # --------------------------------------------------------------------------
+  sisock-weather-server:
+    image: "sisock-weather-server"
+    build: ./components/data_node_servers/weather/
+    depends_on:
+      - "sisock"

--- a/docs/source/datanodeservers.rst
+++ b/docs/source/datanodeservers.rst
@@ -33,14 +33,14 @@ sure to set your date range accordingly.
 
 Configuration
 `````````````
-The image is called ``dans-example-weather``, and should have the general
+The image is called ``sisock-weather-server``, and should have the general
 dependencies. It also communicates over the secure port with the crossbar
 server, and so needs the bind mounted ``.crossbar`` directory.
 
 .. code-block:: yaml
 
     weather:
-      image: grumpy.physics.yale.edu/dans-example-weather:0.1.0
+      image: grumpy.physics.yale.edu/sisock-weather-server:latest
       depends_on:
         - "sisock-crossbar"
         - "sisock-http"
@@ -63,14 +63,14 @@ This is a fun early demo, but probably won't be useful to many users.
 
 Configuration
 `````````````
-The image is called ``dans-example-sensors``, and should have the general
+The image is called ``sisock-sensors-server``, and should have the general
 dependencies. It also communicates over the secure port with the crossbar
 server, and so needs the bind mounted ``.crossbar`` directory.
 
 .. code-block:: yaml
 
     sensors:
-      image: grumpy.physics.yale.edu/dans-example-sensors:0.1.0
+      image: grumpy.physics.yale.edu/sisock-sensors-server:latest
       depends_on:
         - "sisock-crossbar"
         - "sisock-http"
@@ -85,7 +85,7 @@ production at the ACT site.
 
 Configuration
 `````````````
-The image is called ``dans-apex-weather``, and should have the general
+The image is called ``sisock-apex-weather-server``, and should have the general
 dependencies. It also communicates over the secure port with the crossbar
 server, and so needs the bind mounted ``.crossbar`` directory. In addition, you
 will need to mount the location that the data is stored on the host system.
@@ -97,7 +97,7 @@ at large time ranges, where fine resolution is not needed.
 .. code-block:: yaml
 
     apex-weather:
-      image: grumpy.physics.yale.edu/dans-apex-weather:0.1.0
+      image: grumpy.physics.yale.edu/sisock-apex-weather-server:latest
       volumes:
         - ./.crossbar:/app/.crossbar:ro
         - /var/www/apex_weather:/data:ro
@@ -120,7 +120,7 @@ Retrieval of data written to disk is a work in progress.
 
 Configuration
 `````````````
-The image is called ``dans-thermometry``, and should have the general
+The image is called ``sisock-thermometry-server``, and should have the general
 dependencies. 
 
 There are several environment variables which need to be set uniquely per
@@ -140,7 +140,7 @@ instance of the server:
 .. code-block:: yaml
 
     LSA23JD:
-      image: grumpy.physics.yale.edu/dans-thermometry:0.1.0
+      image: grumpy.physics.yale.edu/sisock-thermometry-server:latest
       environment:
           TARGET: LSA23JD # match to instance-id of agent to monitor, used for data feed subscription
           NAME: 'LSA23JD' # will appear in sisock a front of field name
@@ -157,7 +157,7 @@ at the ACT site.
 
 Configuration
 `````````````
-The image is called ``dans-ucsc-radiometer``, and should have the general
+The image is called ``sisock-radiometer-server``, and should have the general
 dependencies. It also communicates over the secure port with the crossbar
 server, and so needs the bind mounted ``.crossbar`` directory. In addition, you
 will need to mount the location that the data is stored on the host system.
@@ -169,7 +169,7 @@ at large time ranges, where fine resolution is not needed.
 .. code-block:: yaml
 
     ucsc-radiometer:
-      image: grumpy.physics.yale.edu/dans-ucsc-radiometer:0.1.0
+      image: grumpy.physics.yale.edu/sisock-radiometer-server:latest
       volumes:
         - ./.crossbar:/app/.crossbar:ro
         - /var/www/Skymonitor:/data:ro
@@ -198,7 +198,7 @@ clearing scheme is not implemented).
 
 Configuration
 `````````````
-The image is called ``dans-g3-reader``, and should have the general
+The image is called ``sisock-g3-reader-server``, and should have the general
 dependencies. It also communicates over the secure port with the crossbar
 server, and so needs the bind mounted ``.crossbar`` directory. In addition, you
 will need to mount the location that the data is stored on the host system.
@@ -214,7 +214,7 @@ look like:
 .. code-block:: yaml
 
   g3-reader:
-    image: grumpy.physics.yale.edu/dans-g3-reader:0.2.0
+    image: grumpy.physics.yale.edu/sisock-g3-reader-server:latest
     volumes:
       - /home/koopman/data/yale:/data:ro
       - ./.crossbar:/app/.crossbar
@@ -238,4 +238,3 @@ look like:
       MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
     volumes:
       - database-storage-dev:/var/lib/mysql
-


### PR DESCRIPTION
This will use docker-compose to build all sisock component images and push them to the registry automatically for tagged commits in the master branch.

This PR is mostly a test for this Travis CI conditional. I'm interested to see what is run for the PR itself.

Do note, however, the image names have changed slightly, in preparation for the removal of the term 'data node server'.