### PR TITLE
Improve SQL Query Efficiency

### DIFF
--- a/components/g3_file_scanner/scan.py
+++ b/components/g3_file_scanner/scan.py
@@ -300,35 +300,16 @@ def build_description_table(config):
     cur = cnx.cursor()
     print("SQL server connection established")
 
-    total_time = 0.
-    sql_time = 0.
-
-    t_sub = time.time()
-
     # Get feed_ids and field names from database.
     print("Querying database for all fields")
-    cur.execute("SELECT DISTINCT feed_id, field \
-                 FROM fields")
+    cur.execute("SELECT DISTINCT F.field, E.description \
+                 FROM fields F, feeds E \
+                 WHERE F.feed_id=E.id")
     fields = cur.fetchall()
-    t_ellapsed = time.time() - t_sub
-    sql_time += t_ellapsed
 
     # print("Queried for fields:", fields) # debug
 
-    sql_queries = 1
-    for feed_id, field_name in fields:
-        t_sub = time.time()
-
-        cur.execute("SELECT description FROM feeds WHERE id=%s", (feed_id,))
-        feed_names = cur.fetchall()
-
-        t_ellapsed = time.time() - t_sub
-        sql_time += t_ellapsed
-        sql_queries += 1
-
-        # should find single feed name, else something is wrong
-        assert len(feed_names) == 1
-
+    for field_name, description in fields:
         # Create our timeline names based on the feed
         _field_name = (field_name).lower().replace(' ', '_')
 
@@ -336,7 +317,7 @@ def build_description_table(config):
         # is timestamped independently anyway, and _field_name is not
         # guarenteed to be unique between feeds (i.e. there is a "Channel
         # 01" feed on every Lakeshore).
-        _timeline_name = feed_names[0][0] + '.' + _field_name
+        _timeline_name = description + '.' + _field_name
 
         cur.execute("INSERT IGNORE \
                      INTO description \
@@ -350,8 +331,6 @@ def build_description_table(config):
     cnx.close()
 
     total_time = time.time() - t
-    print("SQL Time:", sql_time)
-    print("SQL Queries:", sql_queries)
     print("Total Time:", total_time)
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,16 @@ Start here for information about the design and use of sisock.
    source/components
    source/datanodeservers
 
+Developer's Guide
+------------------
+
+If you are interested in the details of how individual components work, look here.
+
+.. toctree::
+   :maxdepth: 2
+
+   source/g3filescanner
+
 API Reference
 -------------
 If you are looking for information on a specific function, class or method, this part of the documentation is for you.

--- a/docs/source/g3filescanner.rst
+++ b/docs/source/g3filescanner.rst
@@ -1,0 +1,121 @@
+g3 File Scanner
+===============
+
+Reading back housekeeping data from g3 files written to disk is a key feature
+required of the housekeeping monitor. This task is performed in two parts. The
+first is to scan the files. Each g3 file is read and metadata about what is
+stored in the files is recorded into a MySQL database. The component that
+performs this first task is called the `g3-file-scanner`. The second, is the
+opening and caching of the data in specific g3 files which are requested. This
+is the data server, `g3-reader`. This page describes the inner workings of
+the `g3-file-scanner`.
+
+.. contents:: Contents
+    :local:
+
+Overview
+--------
+
+The `g3-file-scanner` (referred to here as the "file scanner") will scan a
+given directory for files with a `.g3` extension, open them, and record
+metadata about them required for the `g3-reader` data server in a MySQL
+database. The scan occurs on a regular interval, set by the user as an
+environment variable.
+
+.. note::
+
+    The first scan of a large dataset will take some time, depending on how
+    much data you have.
+
+SQL Database Design
+-------------------
+
+The SQL database is split into two tables, the "feeds" table and the "fields"
+table. "feeds" stores the filename and path to the file along with the
+`prov_id` and `description` from within the g3 file. The `description` will be
+used to assemble a unique sisock field name. Additionally, the "feeds" table
+keeps track of whether a scan has completed on the given file (with the
+`scanned` column), and assigns each file a unique `id`.
+
+A description and example of the "feeds" table is shown here:
+
+.. code-block:: mysql
+
+    MariaDB [files]> describe feeds;
+    +-------------+--------------+------+-----+---------+-------+
+    | Field       | Type         | Null | Key | Default | Extra |
+    +-------------+--------------+------+-----+---------+-------+
+    | id          | int(11)      | NO   | PRI | NULL    |       |
+    | filename     | varchar(255) | YES  | MUL | NULL    |       |
+    | path        | varchar(255) | YES  |     | NULL    |       |
+    | prov_id     | int(11)      | YES  |     | NULL    |       |
+    | description | varchar(255) | YES  |     | NULL    |       |
+    | scanned     | tinyint(1)   | NO   |     | 0       |       |
+    +-------------+--------------+------+-----+---------+-------+
+    6 rows in set (0.010 sec)
+    
+    MariaDB [files]> select * from feeds limit 3;
+    +----+------------------------+-------------+---------+---------------------+---------+
+    | id | filename                | path        | prov_id | description         | scanned |
+    +----+------------------------+-------------+---------+---------------------+---------+
+    |  1 | 2019-03-18-16-52-46.g3 | /data/15529 |       0 | observatory.LSA22ZC |       1 |
+    |  2 | 2019-03-18-16-52-46.g3 | /data/15529 |       1 | observatory.LSA23JD |       1 |
+    |  3 | 2019-03-18-16-52-46.g3 | /data/15529 |       3 | observatory.LSA22YG |       1 |
+    +----+------------------------+-------------+---------+---------------------+---------+
+    3 rows in set (0.001 sec)
+
+The "fields" table has a row for each ocs field within a file (i.e. "Channel
+1", "Channel 2", channels for a given Lakeshore device), the start and end
+times for the field, and the correspoding 'id' in the feeds id, stored here as
+"feed_id".
+
+A description and example of the "fields" table is shown here:
+
+.. code-block:: mysql
+
+    MariaDB [files]> describe fields;
+    +---------+--------------+------+-----+---------+-------+
+    | Field   | Type         | Null | Key | Default | Extra |
+    +---------+--------------+------+-----+---------+-------+
+    | feed_id | int(11)      | NO   | MUL | NULL    |       |
+    | field   | varchar(255) | YES  |     | NULL    |       |
+    | start   | datetime(6)  | YES  |     | NULL    |       |
+    | end     | datetime(6)  | YES  |     | NULL    |       |
+    +---------+--------------+------+-----+---------+-------+
+    4 rows in set (0.001 sec)
+    
+    MariaDB [files]> select * from fields limit 3;
+    +---------+-----------+----------------------------+----------------------------+
+    | feed_id | field     | start                      | end                        |
+    +---------+-----------+----------------------------+----------------------------+
+    |       1 | Channel 1 | 2019-03-18 16:51:55.762230 | 2019-03-18 17:01:56.772258 |
+    |       1 | Channel 2 | 2019-03-18 16:51:55.762230 | 2019-03-18 17:01:56.772258 |
+    |       1 | Channel 3 | 2019-03-18 16:51:55.762230 | 2019-03-18 17:01:56.772258 |
+    +---------+-----------+----------------------------+----------------------------+
+    3 rows in set (0.001 sec)
+
+The "description" table is a simple, single column, table containing the
+combined ocs field and ocs descriptions distinctly across all .g3 files. This
+is used as the field list that the g3-reader will return.
+
+A description and example of the "description" table is shown here:
+
+.. code-block:: mysql
+
+    MariaDB [files]> describe description;
+    +-------------+--------------+------+-----+---------+-------+
+    | Field       | Type         | Null | Key | Default | Extra |
+    +-------------+--------------+------+-----+---------+-------+
+    | description | varchar(255) | NO   | PRI | NULL    |       |
+    +-------------+--------------+------+-----+---------+-------+
+    1 row in set (0.001 sec)
+    
+    MariaDB [files]> select * from description limit 3;
+    +----------------------------------+
+    | description                      |
+    +----------------------------------+
+    | observatory.LSA22YE.channel_01_r |
+    | observatory.LSA22YE.channel_01_t |
+    | observatory.LSA22YE.channel_02_r |
+    +----------------------------------+
+    3 rows in set (0.000 sec)


### PR DESCRIPTION
This implements a more efficient SQL query to build the fields list that the g3-reader data server returns. It also adds a table to the database with the built fields list. While probably the field list could be simply generated on each get_fields() call, in my testing I'm finding it a factor of 10 faster to use the description table as I first implemented (~0.0056 seconds to query the description table only vs ~0.058 seconds to build the list from a fresh query on both the fields and feeds table). Since get_fields() is called many times by Grafana I'm going to leave the additional table in to eek out all the speed improvements we can get.

resolves #35 