### PR TITLE
Generalize thermometry data server by adding Feed env variable

### DIFF
--- a/components/data_node_servers/data_feed/Dockerfile
+++ b/components/data_node_servers/data_feed/Dockerfile
@@ -11,7 +11,7 @@ ENV TZ=Etc/UTC
 WORKDIR /app
 
 # Copy the current directory contents into the container at /app
-COPY thermometry_server.py /app/
+COPY data_feed_server.py /app/
 
 # Run app.py when the container launches
-CMD ["python3", "-u", "thermometry_server.py"]
+CMD ["python3", "-u", "data_feed_server.py"]

--- a/components/data_node_servers/data_feed/Makefile
+++ b/components/data_node_servers/data_feed/Makefile
@@ -1,4 +1,4 @@
-NAME=sisock-thermometry-server
+NAME=sisock-data-feed-server
 
 build :
 	docker build -t ${NAME} .

--- a/components/data_node_servers/thermometry/thermometry_server.py
+++ b/components/data_node_servers/thermometry/thermometry_server.py
@@ -183,4 +183,5 @@ if __name__ == '__main__':
     runner.run(thermometry_server(ComponentConfig(u'test_realm', {}),
                                   name=environ['NAME'],
                                   description=environ['DESCRIPTION'],
-                                  target=environ['TARGET']))
+                                  target=environ['TARGET'],
+                                  buffer_time=buffer_length))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,11 +83,11 @@ services:
       - "sisock"
 
   # --------------------------------------------------------------------------
-  # Data node server: Thermometry OCS subscriber
+  # Data node server: OCS data feed subscriber
   # --------------------------------------------------------------------------
-  sisock-thermometry-server:
-    image: "sisock-thermometry-server"
-    build: ./components/data_node_servers/thermometry/
+  sisock-data-feed-server:
+    image: "sisock-data-feed-server"
+    build: ./components/data_node_servers/data_feed/
     depends_on:
       - "sisock"
 


### PR DESCRIPTION
The thermometry data server was subscribing to the OCS data feeds for the Lakeshore devices with a hardcoded crossbar pub/sub address of "observatory.{TARGET}.feeds.temperatures". We now have more than just temperature sensors to readout for live monitoring. This pull request generalizes the data server by adding a "FEED" environment variable and now subscribes using "observatory.{TARGET}.feeds.{FEED}".

I've renamed thermometry to data_feed where needed, and updated the documentation for this data server to describe the FEED parameter.

This change still requires one copy of this data server running per combination TARGET + FEED. The topic of making this server handle all feeds has been brought in conversation, and has certain pros and cons. I will open an Issue to discuss.