### PR TITLE
Use env var if they exist for base CONSTANTs

### DIFF
--- a/docs/source/components.rst
+++ b/docs/source/components.rst
@@ -104,3 +104,30 @@ and only depends on the database we store file information in.
         SCAN_INTERVAL: 3600 # seconds
     depends_on:
       - "database"
+
+Common Configuration
+--------------------
+There are some environment variables which are common among all sisock
+components. These mostly relate to connection settings for the crossbar server.
+The defaults will work for a simple, single node, setup. However, moving to
+multiple nodes, in most cases, will require setting some of these.
+
+.. table::
+   :widths: auto
+
+   =================   ============
+   Option              Description
+   =================   ============
+   WAMP_USER           The username configured for connecting to the crossbar
+                       server. This is the "role" in the crossbar config.
+   WAMP_SECRET         The associated secret for the WAMP_USER.
+   CROSSBAR_HOST       IP or domain name for the crossbar server.
+   CROSSBAR_TLS_PORT   The port configured for secure connection to the
+                       crossbar server. In default SO configurations this is 8080.
+   CROSSBAR_OCS_PORT   The port configured for open connection to the crossbar
+                       server. In default SO configurations this is 8001.
+   =================   ============
+
+.. warning::
+    The default `WAMP_SECRET` is not secure. If you are deploying your crossbar
+    server in a public manner, you should not use the default secret.

--- a/sisock/base.py
+++ b/sisock/base.py
@@ -30,6 +30,7 @@ Constants
 
 import six
 import time
+from os import environ
 from autobahn.twisted.component import Component, run
 from autobahn.twisted.util import sleep
 from autobahn.twisted.wamp import ApplicationSession, ApplicationRunner
@@ -39,12 +40,12 @@ from twisted.python.failure import Failure
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet import threads
 
-WAMP_USER   = u"server"
-WAMP_SECRET = u"Q5#x4%HCmgTsS!Pj"
+WAMP_USER   = environ.get("WAMP_USER", u"server")
+WAMP_SECRET = environ.get("WAMP_SECRET", u"Q5#x4%HCmgTsS!Pj")
 WAMP_URI    = u"wss://127.0.0.1:8080/ws"
-SISOCK_HOST = u"sisock-crossbar"
-SISOCK_PORT = 8080
-OCS_PORT    = 8001
+SISOCK_HOST = environ.get("CROSSBAR_HOST", u"sisock-crossbar")
+SISOCK_PORT = int(environ.get("CROSSBAR_TLS_PORT", 8080))
+OCS_PORT    = int(environ.get("CROSSBAR_OCS_PORT", 8001))
 REALM       = u"test_realm"
 BASE_URI    = u"org.simonsobservatory"
 


### PR DESCRIPTION
This relates to #31. Even running on a second system with Docker, if not additional tools (like Docker swarm) are involved, then the name resolution we rely on within the Docker environment doesn't work across computers. We need a way to pass in our own addresses/etc. for the constants defined in `base.py`.

This simply tries to grab them from an environment variable, and if not available falls back to the previous settings. This is a nice solution for now since it doesn't require any changes in the data servers/sisock components to work.

If this looks alright, I'll add documentation to the various components for the new environment variables before merging.