### PR TITLE
Use HKArchiveScanner in g3-reader Data Sever

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 # A containerized sisock installation.
 
 # Build on so3g base image
-#FROM simonsobs/so3g:v0.0.4-39-g14853f8
-FROM so3g:latest
+FROM simonsobs/so3g:v0.0.4-48-g29344cf
 
 # Set timezone to UTC
 ENV TZ=Etc/UTC

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 # A containerized sisock installation.
 
 # Build on so3g base image
-FROM simonsobs/so3g:v0.0.4-32-g7b9a908
+#FROM simonsobs/so3g:v0.0.4-39-g14853f8
+FROM so3g:latest
 
 # Set timezone to UTC
 ENV TZ=Etc/UTC

--- a/components/data_node_servers/g3_reader/g3_reader.py
+++ b/components/data_node_servers/g3_reader/g3_reader.py
@@ -108,7 +108,13 @@ def _read_data_from_disk(data_cache, file_list):
     """
     hkcs = HKArchiveScanner()
     for filename in file_list:
-        hkcs.process_file(filename)
+        try:
+            hkcs.process_file(filename)
+        except RuntimeError:
+            self.log.warn("Exception raised while reading file {_f}," +
+                          "likely the file is not yet done writing",
+                          _f=filename)
+
     archive = hkcs.finalize()
 
     return archive

--- a/components/data_node_servers/g3_reader/g3_reader.py
+++ b/components/data_node_servers/g3_reader/g3_reader.py
@@ -25,14 +25,12 @@ from twisted.internet._sslverify import OpenSSLCertificateAuthorities
 from twisted.internet.ssl import CertificateOptions
 from OpenSSL import crypto
 
-import so3g
 import sisock
-from spt3g import core
-from spt3g.core import G3FrameType
 from so3g.hk import HKArchiveScanner
 
 # For logging
 txaio.use_twisted()
+
 
 def _build_file_list(cur, start, end):
     """Build the file list to read in all the data within a given start/end
@@ -111,83 +109,13 @@ def _read_data_from_disk(data_cache, file_list):
         try:
             hkcs.process_file(filename)
         except RuntimeError:
-            self.log.warn("Exception raised while reading file {_f}," +
-                          "likely the file is not yet done writing",
-                          _f=filename)
+            print("Exception raised while reading file {_f}," +
+                  "likely the file is not yet done writing",
+                  _f=filename)
 
     archive = hkcs.finalize()
 
     return archive
-
-
-def _format_data_cache_for_sisock(cache, start, end, max_points=0):
-    """Format for return from sisock API.
-
-    Parameters
-    ----------
-    cache : dict
-        Cache of the data read from disk.
-    start : float
-        Starting unix timestamp, before which we won't return data
-    end : float
-        Ending unix timestamp, after which we won't return data
-    max_points : int
-        Maximum number of points to return, 0 returns all points.
-
-    Returns
-    -------
-    dict
-        dictionary structured for return from the sisock API
-
-    """
-
-    _data = {'data': {},
-             'timeline': {}}
-
-    # Needs to be sorted so that data is displayed properly in grafana
-    filenames = list(cache.keys())
-    filenames.sort()
-
-    for filename in filenames:
-        contents = cache[filename]
-        for field, data in contents['Timestamps'].items():
-            # Add timelines to _data['timeline']
-            if field not in _data['timeline']:
-                _data['timeline'][field] = {'t': [], 'finalized_until': None}
-
-            full_t = np.array(data)
-            t_idx = np.logical_and(full_t > start, full_t < end)
-            t_cut = full_t[t_idx]
-            _data['timeline'][field]['t'] += t_cut.tolist()
-
-            # Add data to _data['data']
-            if field not in _data['data']:
-                _data['data'][field] = []
-
-            #print("T_IDX", t_idx)
-            #print("LOOK", contents['TODs'][field])
-            _data['data'][field] += np.array(contents['TODs'][field])[t_idx].tolist()
-
-    # Determine 'finalized_until' time for each timeline
-    for field in _data['timeline']:
-        try:
-            _data['timeline'][field]['finalized_until'] = np.max(_data['timeline'][field]['t'])
-        except Exception as e:
-            _data['timeline'][field]['finalized_until'] = None
-            print("%s occured on field '%s', unable to determine 'finalized_until' time, \
-                  setting to None..." % (type(e), field))
-
-    # Limit maximum number of points to return.
-    if max_points != 0:
-        for field in _data['data']:
-            if max_points < len(_data['data'][field]):
-                limiter = range(0, len(_data['data'][field]),
-                                int(len(_data['data'][field])/max_points))
-                _data['data'][field] = np.array(_data['data'][field])[limiter].tolist()
-                _data['timeline'][field]['t'] = np.array(_data['timeline'][field]['t'])[limiter].tolist()
-                _data['timeline'][field]['finalized_until'] = _data['timeline'][field]['t'][-1]
-
-    return _data
 
 
 def _format_sisock_time_for_sql(sisock_time):
@@ -253,6 +181,48 @@ def _cast_data_timeline_to_list(data, timeline):
         _new_timeline[k] = new_v
 
     return _new_data, _new_timeline
+
+
+def _down_sample_data(get_data_dict, max_points):
+    """Simple downsampling via numpy slicing.
+
+    Slices data using a step size determined by len(array)/max_points. Will not
+    capture details like single sample spikes, etc, but should allow us to use
+    the g3-reader for larget datasets until better downsampling to file is
+    implemented.
+
+    Parameters
+    ----------
+    get_data_dict : dict
+        Dictionary that we've built for get_data, fully sampled
+    max_points : int
+        The maximum number of points per field to return (roughly anyway)
+
+    Returns
+    -------
+    dict
+        A dictionary with the same layout as get_data_dict, just downsampled
+
+    """
+    new_get_data_array = {'data': {}, 'timeline': {}}
+    for field, data_array in get_data_dict['data'].items():
+        if max_points < len(data_array):
+            step = int(len(data_array)/max_points)
+            new_get_data_array['data'][field] = np.array(data_array)[::step].tolist()
+        else:
+            new_get_data_array['data'][field] = data_array
+
+    for group, timeline_dict in get_data_dict['timeline'].items():
+        if max_points < len(timeline_dict['t']):
+            step = int(len(timeline_dict['t'])/max_points)
+            new_get_data_array['timeline'][group] = {'t': np.array(timeline_dict['t'])[::step].tolist()}
+            new_get_data_array['timeline'][group]['fields'] = timeline_dict['fields']
+            new_get_data_array['timeline'][group]['finalized_until'] = np.array(timeline_dict['t'])[::step][-1]
+        else:
+            new_get_data_array['timeline'][group] = timeline_dict
+
+    return new_get_data_array
+
 
 class G3ReaderServer(sisock.base.DataNodeServer):
     """A DataNodeServer serving housekeeping data stored in .g3 format on disk."""
@@ -370,47 +340,16 @@ class G3ReaderServer(sisock.base.DataNodeServer):
         _new_data, _new_timeline = _cast_data_timeline_to_list(_data, _timeline)
         _formatting = {"data": _new_data, "timeline": _new_timeline}
 
-        #t = time.time()
-        #_formatting = _format_data_cache_for_sisock(self.data_cache, start,
-        #                                            end, max_points=self.max_points)
-        #t_ellapsed = time.time() - t
-        #print("Formatted data in: {} seconds".format(t_ellapsed))
-        #print("Formatted data:", _formatting) # debug
-
-        #print(_formatting['data'].keys())
-        #print(_formatting['timeline'].keys())
-
-        group_map = {}
-        for group, v in _formatting['timeline'].items():
-            for _field in v['fields']:
-                group_map[_field] = group
-        self.log.debug('group_map: {}'.format(group_map))
-
-        # Naive downsampling - make function which takes final dictionary we
-        # want to return, down samples it, and returns something we can spit
-        # out of get_data
-        max_points = self.max_points
-        _new_result = {'data': {}, 'timeline': {}}
-        for field, data_array in _formatting['data'].items():
-            if max_points < len(data_array):
-                step = int(len(data_array)/max_points)
-                _new_result['data'][field] = np.array(data_array)[::step].tolist()
-            else:
-                _new_result['data'][field] = data_array
-
-        for group, timeline_dict in _formatting['timeline'].items():
-            if max_points < len(timeline_dict['t']):
-                step = int(len(timeline_dict['t'])/max_points)
-                _new_result['timeline'][group] = {'t': np.array(timeline_dict['t'])[::step].tolist()}
-                _new_result['timeline'][group]['fields'] = timeline_dict['fields']
-                _new_result['timeline'][group]['finalized_until'] = np.array(timeline_dict['t'])[::step][-1]
-            else:
-                _new_result['timeline'][group] = timeline_dict
+        # Downsample the data
+        t = time.time()
+        result = _down_sample_data(_formatting, self.max_points)
+        t_ellapsed = time.time() - t
+        self.log.debug("Downsampled data in: {time} seconds", time=t_ellapsed)
 
         total_time_data = time.time() - t_data
-        print("Time to get data:", total_time_data)
+        self.log.debug("Time to get data: {time}", time=total_time_data)
 
-        return _new_result
+        return result
 
 
 if __name__ == "__main__":
@@ -446,8 +385,8 @@ if __name__ == "__main__":
                   'db': environ['SQL_DB']}
 
     # Start our component.
-    runner = ApplicationRunner("wss://%s:%d/ws" % (sisock.base.SISOCK_HOST, \
-                                                   sisock.base.SISOCK_PORT), \
+    runner = ApplicationRunner("wss://%s:%d/ws" % (sisock.base.SISOCK_HOST,
+                                                   sisock.base.SISOCK_PORT),
                                sisock.base.REALM, ssl=opt)
     runner.run(G3ReaderServer(ComponentConfig(sisock.base.REALM, {}),
                               sql_config=SQL_CONFIG))

--- a/components/g3_file_scanner/scan.py
+++ b/components/g3_file_scanner/scan.py
@@ -312,7 +312,7 @@ def build_description_table(config):
 
     for field_name, description in fields:
         # Create our timeline names based on the feed
-        _field_name = (field_name).lower().replace(' ', '_')
+        _field_name = field_name
 
         # Actually using for both timeline and field names, as each field
         # is timestamped independently anyway, and _field_name is not

--- a/components/grafana_server/grafana_http_json.py
+++ b/components/grafana_server/grafana_http_json.py
@@ -256,13 +256,20 @@ class GrafanaSisockDatasrc(object):
                 for group, v in _timelines.items():
                     for _field in v['fields']:
                         group_map[_field] = group
-                self.log.debug(f'group_map: {group_map}')
+                self.log.debug('group_map: {g}', g=group_map)
 
                 for f in field:
-                    tl_name = group_map[f]
-                    tl = np.array(_timelines[tl_name]["t"]) * 1000.0
-                    d = {"target": data_node + "::" + f,
-                         "datapoints": list(zip(_data[f], tl))}
+                    self.log.debug("Processing field {_f}", _f=f)
+                    if f in group_map:
+                        tl_name = group_map[f]
+                        tl = np.array(_timelines[tl_name]["t"]) * 1000.0
+                        d = {"target": data_node + "::" + f,
+                             "datapoints": list(zip(_data[f], tl))}
+                    else:
+                        self.log.debug('field {_f} not found in group_map,' +
+                                       'returning empty list', _f=f)
+                        # Results in name showing up in key, but no data points
+                        d = {"target": data_node + "::" + f, "datapoints": []}
                     res.append(d)
             else:
                 # Loop through the fields and convert to something that we can

--- a/components/grafana_server/grafana_http_json.py
+++ b/components/grafana_server/grafana_http_json.py
@@ -243,7 +243,7 @@ class GrafanaSisockDatasrc(object):
             # Identifies HKArchiveScanner API in use by generic 'group0' used
             # in its output. This is kind of a hack.
             if 'group0' in data['timeline']:
-                print("Detected results from HKArchiveScanner use")
+                self.log.debug("Detected results from HKArchiveScanner use")
                 _timelines = data['timeline']
                 _data = data['data']
                 self.log.debug(f'Querying for data in fields: {field}')
@@ -379,7 +379,7 @@ def main(reactor):
     comp_d = component.start(reactor)
 
     # When not using run() we also must start logging ourselves.
-    txaio.start_logging(level='info')
+    txaio.start_logging(level=environ.get("LOGLEVEL", "info"))
 
     # If the Component raises an exception we want to exit. Note that
     # things like failing to connect will be swallowed by the

--- a/components/grafana_server/grafana_http_json.py
+++ b/components/grafana_server/grafana_http_json.py
@@ -283,15 +283,14 @@ class GrafanaSisockDatasrc(object):
                     try:
                         tl_name = self._field[data_node][0][f]["timeline"]
                         tl = np.array(data["timeline"][tl_name]["t"]) * 1000.0
-                    except Exception as e:
-                        print("%s occurred with field '%s', skipping..." %
-                              (type(e), f))
-                        print("error:", e.message)
-                        continue
-
-                    # Now build the response for this field.
-                    d = {"target": data_node + "::" + f,
-                         "datapoints": list(zip(data["data"][f], tl))}
+                        # Now build the response for this field.
+                        d = {"target": data_node + "::" + f,
+                             "datapoints": list(zip(data["data"][f], tl))}
+                    except KeyError:
+                        self.log.debug('field {_f} not found,' +
+                                       'returning empty list', _f=f)
+                        # Results in name showing up in key, but no data points
+                        d = {"target": data_node + "::" + f, "datapoints": []}
                     res.append(d)
 
         # Convert to JSON and send off to grafana.

--- a/docs/source/components.rst
+++ b/docs/source/components.rst
@@ -63,7 +63,9 @@ The image is provided at ``grumpy.physics.yale.edu/sisock-http``, and depends
 on the crossbar server running to function. Since it communicates over the
 secure port on crossbar we need the TLS certificates mounted. The HTTP server
 defaultly runs on port 5000, but you can change this with the environment
-variable 'PORT', as shown in the example.
+variable 'PORT', as shown in the example. There is also a 'LOGLEVEL'
+environment variable which can be used to set the log level. This is useful for
+debugging. txaio is used for logging.
 
 .. code-block:: yaml
 
@@ -73,6 +75,7 @@ variable 'PORT', as shown in the example.
         - "sisock-crossbar"
       environment:
         PORT: "5001"
+        LOGLEVEL: "info"
       volumes:
         - ./.crossbar:/app/.crossbar:ro
 


### PR DESCRIPTION
This PR replaces the custom G3 Pipeline for opening files with the use of the so3g HKArchive object and it's associated `get_data()` method.

This begins work on #29.

## g3-reader
The `G3ReaderServer` has three attributes which keep track of the data cache:

1. `cache_list`, which keeps track of files we've already processed with the HKArchiveScanner
2. `hkas`, the HKArchiveScanner object
3. `archive`, the HKArchive object

When a query is issued by Grafana new files which aren't in the `cache_list` already will be processed by the `hkas` and `archive` will be updated with the HKArchive object returned by `hkas.finalize()`.

`archive.get_data()` is then used to retrieve the data between the timestamps requested. We still naively downsample using `MAX_POINTS` so that we don't overwhelm the communication protocol (also because it wouldn't make sense displaying such high resolution data most of the time.) We would still benefit from downsampling to disk though so that we can avoid loading full resolution data all the time. 

## g3-file-scanner
Small change here, but one that requires action from users already using the g3-reader/file-scanner/database. I was previously removing spaces and lowercasing field names that got logged in the database. This would cause issues where in the so3g bits this wasn't occurring, so I took this out. Users will need to essentially wipe their DB instances and allow an updated g3-file-scanner rescan their data.

## sisock-http
Due to differences in the implementation of the `get_fields`/`get_data` API in the so3g hk code using so3g's `get_data` isn't exactly a drop-in replacement within sisock. Details in #45, but the main thing is that timeline names are dynamically assigned in so3g, so that you can't cache the results from `get_fields` and expect them to match a later call to `get_data`. Since this is how sisock was designed sisock-http expects to be able to cache the `get_fields` results.

I've accommodated this in a sort of hacked way by identifying we've returned things from so3g's `get_data` by looking for it's first default dynamically generated field name 'group0', and then processing the results differently. This section does repeat a bit of code from the previous processing, but the error handling was different enough that I've not tried to make it nicer. Eventually, depending on how we handle #45 we might switch to using the new processing code in all instances.

## Misc.
* Started using txaio logging in more places, particularly for debug statements.
* Added ability to set the log level via environment variable.

I've tested this both locally on a small subset of data, but also on all the HK data we've collected at Yale. Just yesterday we set the SAT1 system up with this updated g3-reader as well, as they are the heaviest user of the reader at the moment, and would benefit from any speed increases.

Overall this is dramatically faster than what we have currently. Several days of data can still take ~10 seconds to load ~25 timestreams on first load. 