### PR TITLE
Introduce testing via twisted's unittest interface

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,14 @@
 [report]
 omit = sisock/_version.py
+
+exclude_lines =
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+[run]
+omit =
+    */site-packages/*
+    */distutils/*
+    tests/*
+    sisock/old.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 stages:
   - test
   - name: dockerize
-    if: branch = master OR tag IS present
+    if: branch = master AND type = push OR tag IS present
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 stages:
   - test
   - name: dockerize
-    if: branch = master
+    if: branch = master OR tag IS present
 
 jobs:
   include:
@@ -18,7 +18,7 @@ jobs:
       install:
         - pip install -r requirements.txt .
       script:
-        - pytest --cov sisock tests/
+        - coverage run -m unittest
 
       after_success: coveralls
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,16 @@ remove the grafana-storage container:
 $ docker volume rm grafana-storage
 ```
 
+## Testing
+We currently use the unittest module provided by twisted for testing. Code
+coverage is provided by the coverage module. coverage can command test runners.
+You can run the unittests from the top level directory with:
+
+```
+$ coverage run -m unittest
+$ coverage report
+```
+
 ## License
 
 This project is licensed under the BSD 2-Clause License - see the [LICENSE.txt](LICENSE.txt) file for details.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ twisted
 pytest
 pytest-cov
 coveralls
+coverage

--- a/tests/test_data_feed_server.py
+++ b/tests/test_data_feed_server.py
@@ -1,0 +1,180 @@
+import sys, os
+sys.path.insert(0, os.path.dirname("./components/data_node_servers/data_feed/"))
+from data_feed_server import data_feed_server
+
+import mock
+import time
+
+from twisted.trial import unittest
+from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks, Deferred, returnValue
+
+class TestDataFeedServerClass(unittest.TestCase):
+    """Test the data_feed_server ApplicationSession.
+
+    There is not a lot of documentation for properly testing twisted/WAMP
+    applications. The start of this was based on this blog post:
+    https://medium.com/@headquartershq/using-mock-and-trial-to-create-unit-tests-for-crossbar-applications-867e5b941cf2
+
+    """
+
+    def setUp(self):
+        #print('setUp was run')
+        config = mock.MagicMock()
+        self.app_session = data_feed_server(config, 'test', 'description', 'feed', target='testing')
+
+    def tearDown(self):
+        #print('tearDown was run')
+        del(self.app_session)
+        #print(self.app_session.data)
+
+    @inlineCallbacks
+    def mock_call(self, procedure, value, *args, **kwargs):
+        """twisted way to test an inlineCallback."""
+        d = Deferred()
+        reactor.callLater(0, d.callback, [], {})
+        result = yield d
+        returnValue(result)
+
+    def test_extend_data(self):
+        """Tests extend_data(). This should populate the application session's
+        data dictionary with the data in 'message'.
+
+        Here we test for particular values from our example message.
+
+        """
+        # Mock the "call" method to use the above one
+        #self.app_session.call = mock.MagicMock(side_effect=self.mock_call)
+
+        t = time.time()
+        message = {'temps': {'block_name': 'temps',
+                   'data': {'Channel 1 T': [1.0, 2.0, 3.0, 4.0],
+                            'Channel 1 V': [5.0, 6.0, 7.0, 8.0],
+                            'Channel 2 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 2 V': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 3 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 3 V': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 4 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 4 V': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 5 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 5 V': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 6 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 6 V': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 7 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 7 V': [0.0, 0.0, 8.8, 0.0],
+                            'Channel 8 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 8 V': [0.0, 0.0, 0.0, 0.0]},
+                   'timestamps': [t, t+1, t+2, t+3],
+                   'prefix': ''}}
+        self.app_session.extend_data(message)
+
+        # Test data points make it into session data
+        self.assertEqual(self.app_session.data['channel_1_t']['data'], [1, 2, 3, 4])
+        self.assertEqual(self.app_session.data['channel_7_v']['data'], [0, 0, 8.8, 0])
+
+        # Test time makes it into session data, should be 1 second apart
+        self.assertEqual(self.app_session.data['channel_1_t']['time'][0], t)
+        t_diff = self.app_session.data['channel_1_t']['time'][1] - \
+                 self.app_session.data['channel_1_t']['time'][0]
+        self.assertEqual(t_diff, 1.0)
+
+    @inlineCallbacks
+    def test_get_data(self):
+        """Test get_data().
+
+        This tests the get_data call in the data_feed_server. Annoyingly I
+        don't fully understand properly cleaning up ApplicationSessions, so data
+        inserted into the self.app_session.data dictionary is persistent
+        between tests. We insert data further in the future to avoid other
+        data. This should be fixed, I'm just not sure how...
+
+        """
+        # Mock the "call" method to use the above one
+        self.app_session.call = mock.MagicMock(side_effect=self.mock_call)
+        t = time.time()
+        message = {'temps': {'block_name': 'temps',
+                   'data': {'Channel 1 T': [1.0, 2.0, 3.0, 4.0],
+                            'Channel 1 V': [5.0, 6.0, 7.0, 8.0],
+                            'Channel 2 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 2 V': [2.0, 3.0, 4.0, 5.0],
+                            'Channel 3 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 3 V': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 4 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 4 V': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 5 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 5 V': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 6 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 6 V': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 7 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 7 V': [0.0, 0.0, 8.8, 0.0],
+                            'Channel 8 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 8 V': [0.0, 0.0, 0.0, 0.0]},
+                   'timestamps': [t+10, t+11, t+12, t+13],
+                   'prefix': ''}}
+        self.app_session.extend_data(message)
+        result = yield self.app_session.get_data(['channel_2_v'], t+10, t+15)
+
+        # Check data returned is the data we inserted
+        self.assertEqual(result['data']['channel_2_v'], [2, 3, 4, 5])
+
+        # Check top level structure of dictionary
+        self.assertIn('data', result.keys())
+        self.assertIsInstance(result['data'], dict)
+        self.assertIn('timeline', result.keys())
+        self.assertIsInstance(result['timeline'], dict)
+
+        # Test except block when key doesn't exist
+        value = yield self.app_session.get_data(['test'], 1, 2)
+
+    @inlineCallbacks
+    def test_get_fields(self):
+        """Test get_fields().
+
+        This tests the get_fields call in the data_feed_server. This has the
+        same problem as the get_data test, so again we move the data further
+        into the future.
+
+        """
+        # Mock the "call" method to use the above one
+        self.app_session.call = mock.MagicMock(side_effect=self.mock_call)
+        t = time.time()
+        message = {'temps': {'block_name': 'temps',
+                   'data': {'Channel 1 T': [1.0, 2.0, 3.0, 4.0],
+                            'Channel 1 V': [5.0, 6.0, 7.0, 8.0],
+                            'Channel 2 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 2 V': [2.0, 3.0, 4.0, 5.0],
+                            'Channel 3 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 3 V': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 4 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 4 V': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 5 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 5 V': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 6 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 6 V': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 7 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 7 V': [0.0, 0.0, 8.8, 0.0],
+                            'Channel 8 T': [0.0, 0.0, 0.0, 0.0],
+                            'Channel 8 V': [0.0, 0.0, 0.0, 0.0]},
+                   'timestamps': [t+20, t+21, t+22, t+23],
+                   'prefix': ''}}
+        self.app_session.extend_data(message)
+        result = yield self.app_session.get_fields(t+20, t+25)
+
+        # Check that two dictionaries are returned
+        self.assertIsInstance(result[0], dict)
+        self.assertIsInstance(result[1], dict)
+
+        # Check field dict structure
+        self.assertIn('channel_1_t', result[0].keys())
+        self.assertIn('description', result[0]['channel_1_t'].keys())
+        self.assertIn('timeline', result[0]['channel_1_t'].keys())
+        self.assertIn('type', result[0]['channel_1_t'].keys())
+        self.assertIn('units', result[0]['channel_1_t'].keys())
+        self.assertIn(result[0]['channel_1_t']['type'], ["number", "string", "bool"])
+
+        # Check timeline dict structure
+        self.assertIn('observatory.testing.channel_1_t', result[1].keys())
+        self.assertIn('interval', result[1]['observatory.testing.channel_1_t'].keys())
+        self.assertIn('field', result[1]['observatory.testing.channel_1_t'].keys())
+        self.assertIsInstance(result[1]['observatory.testing.channel_1_t']['field'], list)
+        self.assertIn('channel_1_t', result[1]['observatory.testing.channel_1_t']['field'])

--- a/tests/test_sisock.py
+++ b/tests/test_sisock.py
@@ -1,4 +1,73 @@
 import sisock
+import mock
 
-def test_sisock_uri():
-    assert sisock.base.uri('test') == 'org.simonsobservatory.test'
+from twisted.trial import unittest
+from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks, Deferred, returnValue
+
+class TestSisockBaseFunctions(unittest.TestCase):
+    """Test functions within the sisock base module."""
+    def test_sisock_uri(self):
+        """Test URI construction, which just combines the BASE_URI with the
+        argument.
+        """
+        self.assertEqual(sisock.base.uri('test'), 'org.simonsobservatory.test')
+
+    def test_sisock_to_unix_time(self):
+        """Test sisock timestamp to unix time conversion.
+
+        Input is a unix ctime, or a negative float which is used to set a time
+        t seconds from now. This is a harder case to test, as it dynamically makes a
+        time based on the current time stamp. We just test that it's not
+        returning the negative value (which would be the default if it wasn't properly
+        checked.)
+
+        """
+        # Test positive input (a fixed ctime)
+        t = 1571772601.4099216
+        self.assertEqual(sisock.base.sisock_to_unix_time(t), 1571772601.4099216)
+
+        # Test negative input, which should return time.time() + t input
+        self.assertNotEqual(sisock.base.sisock_to_unix_time(-1), -1)
+
+class TestDataNodeServerClass(unittest.TestCase):
+    """Test the sisock base DataNodeSever ApplicationSession.
+
+    There is not a lot of documentation for properly testing twisted/WAMP
+    applications. The start of this was based on this blog post:
+    https://medium.com/@headquartershq/using-mock-and-trial-to-create-unit-tests-for-crossbar-applications-867e5b941cf2
+
+    """
+
+    def setUp(self):
+        self.app_session = sisock.base.DataNodeServer()
+
+    @inlineCallbacks
+    def mock_call(self, procedure, value, *args, **kwargs):
+        """twisted way to test an inlineCallback."""
+        d = Deferred()
+        reactor.callLater(0, d.callback, [], {})
+        result = yield d
+        returnValue(result)
+
+    @inlineCallbacks
+    def test_direct_get_data_call(self):
+        """get_data should raise an error if _get_data_blocking isn't
+        overridden. Make the call and test that.
+
+        """
+        # Mock the "call" method to use the above one
+        self.app_session.call = mock.MagicMock(side_effect=self.mock_call)
+        with self.assertRaises(RuntimeError):
+            value = yield self.app_session.get_data('test', 1, 2)
+
+    @inlineCallbacks
+    def test_direct_get_data_fields(self):
+        """get_fields should raise an error if _get_fields_blocking isn't
+        overridden. Make the call and test that.
+
+        """
+        # Mock the "call" method to use the above one
+        self.app_session.call = mock.MagicMock(side_effect=self.mock_call)
+        with self.assertRaises(RuntimeError):
+            value = yield self.app_session.get_fields(1, 2)


### PR DESCRIPTION
This was sort of an exploratory exercise in using twisted's unittest interface and I think is a step in the right direction of producing useful testing of code within this repo. This also switches the test runner from pytest to coverage in the travis configuration. coveralls is still used for displaying test coverage.